### PR TITLE
Normalize config import/export and enhance webview guidance

### DIFF
--- a/webview/index.html
+++ b/webview/index.html
@@ -9,7 +9,7 @@
 <body>
     <div id="content">
         <div class="header-row">
-            <div class="filename-display">
+            <div class="filename-display" data-help="Mostra o arquivo atualmente analisado e o escopo ativo.">
                 <h3 class="file-path">
                     <img class="file-icon" src="{{codeFileIcon}}" width="20" height="20" alt="File" title="Current file">
                     {{filePath}}
@@ -20,10 +20,11 @@
                 </div>
             </div>
             
-            <div class="checkbox-dropdown">
+            <div class="checkbox-dropdown" data-help="Acesso rápido a ajuda, simulações financeiras e suporte, além de filtros para o diagrama.">
                 <div class="top-buttons">
                     <button id="helpBtn" class="control-button">?</button>
                     <button id="bugReportBtn" class="control-button">!</button>
+                    <button id="financingBtn" class="control-button" title="Abrir aplicativo de financiamento">Finanças</button>
                 </div>
                 <button type="button" class="dropdown-toggle" id="dropdownToggle">
                     <img class="filter-icon" src="{{filterIcon}}" width="18" height="18" alt="Filter" title="Filters for the diagram">
@@ -31,56 +32,56 @@
                     <span class="dropdown-icon">▼</span>
                 </button>
               <div class="dropdown-content" id="dropdownContent">
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Alterna a exibição de instruções print no fluxograma.">
                   <input type="checkbox" id="showPrints" checked>
                   <label for="showPrintsCheckbox">Show Prints</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Mostra blocos de definição de funções.">
                   <input type="checkbox" id="showFunctions" checked>
                   <label for="showFunctionsCheckbox">Show Functions</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Exibe laços for identificados no código.">
                   <input type="checkbox" id="showForLoops" checked>
                   <label for="showForLoopsCheckbox">Show For Loops</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Exibe laços while identificados no código.">
                   <input type="checkbox" id="showWhileLoops" checked>
                   <label for="showWhileLoopsCheckbox">Show While Loops</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Mostra atribuições de variáveis e atualizações de estado.">
                   <input type="checkbox" id="showVariables" checked>
                   <label for="showVariablesCheckbox">Show Variables</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Inclui condições if/elif/else no fluxo.">
                   <input type="checkbox" id="showIfs" checked>
                   <label for="showIfsCheckbox">Show Ifs</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Mostra instruções import e from import com o formato padronizado.">
                   <input type="checkbox" id="showImports" checked>
                   <label for="showImportsCheckbox">Show Imports</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Apresenta retornos explícitos nas funções.">
                   <input type="checkbox" id="showReturns" checked>
                   <label for="showReturnsCheckbox">Show Returns</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Inclui blocos de tratamento de exceções e finalizações.">
                   <input type="checkbox" id="showExceptions" checked>
                   <label for="showExceptionsCheckbox">Show Exceptions</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Mostra classes e seus relacionamentos.">
                   <input type="checkbox" id="showClasses" checked>
                   <label for="showClassesCheckbox">Show Classes</label>
                 </div>
-                <div class="checkbox-item">
+                <div class="checkbox-item" data-help="Agrupa nós consecutivos semelhantes para simplificar o diagrama.">
                   <input type="checkbox" id="mergeCommonNodes" checked>
                   <label for="mergeCommonNodesCheckbox">Merge Common Nodes</label>
                 </div>
               </div>
             </div>
         </div>
-        
+
         <div class="controls-row">
-            <div class="button-group">
+            <div class="button-group" data-help="Ações principais: gerar novamente, baixar como PNG, salvar e abrir diagramas salvos.">
                 <button id="regenerateBtn" class="control-button">
                     <img class="button-icon" src="{{restartIcon}}" width="25" height="25" alt="Regenerate" title="Regenerate the diagram">
                     Regenerate
@@ -101,7 +102,7 @@
         </div>
         
         <!-- Saved Diagrams Floating List -->
-        <div id="savedDiagramsList" class="saved-diagrams-list hidden">
+        <div id="savedDiagramsList" class="saved-diagrams-list hidden" data-help="Galeria flutuante com fluxogramas salvos. Clique em um item para abrir ou use o ícone para excluir.">
             <div class="saved-diagrams-header">
                 <h4>Saved Diagrams</h4>
                 <span id="savedDiagramsCount" class="saved-diagrams-count">0 files</span>
@@ -126,6 +127,7 @@
                         <p>• Add a minimap to the diagram</p>
                         <p>• Add a theme-selection dropdown</p>
                         <p>• Add support to multi file flowchart rendering.</p>
+                        <p>• Fontes podem representar aportes de pessoas diferentes ao usar o simulador de finanças.</p>
                     </div>
                 </div>
             </div>
@@ -155,9 +157,47 @@
                 </div>
             </div>
         </div>
+        <!-- Financing Modal -->
+        <div id="financingModal" class="modal hidden">
+            <div class="modal-backdrop"></div>
+            <div class="modal-content financing-modal-content" data-help="Simule rapidamente parcelas e distribuições de investimento por fonte.">
+                <div class="modal-header">
+                    <h3>Simulador de Financiamento</h3>
+                    <button class="modal-close" id="financingModalClose">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <p class="financing-description">Informe o valor desejado, a taxa mensal e o prazo para estimar parcelas. Utilize as fontes para registrar investimentos de pessoas diferentes e entender a participação de cada uma.</p>
+                    <form id="financingForm" class="financing-form">
+                        <div class="financing-field" data-help="Valor total que será financiado ou investido.">
+                            <label for="financingAmount">Valor total (R$)</label>
+                            <input type="number" id="financingAmount" min="0" step="0.01" placeholder="Ex.: 50000">
+                        </div>
+                        <div class="financing-field" data-help="Taxa de juros mensal aplicada ao financiamento.">
+                            <label for="financingRate">Taxa mensal (%)</label>
+                            <input type="number" id="financingRate" min="0" step="0.01" placeholder="Ex.: 1.2">
+                        </div>
+                        <div class="financing-field" data-help="Quantidade de meses para quitar o valor.">
+                            <label for="financingMonths">Prazo (meses)</label>
+                            <input type="number" id="financingMonths" min="1" step="1" placeholder="Ex.: 36">
+                        </div>
+                        <div class="financing-sources-card" data-help="Adicione fontes para representar aportes de pessoas diferentes.">
+                            <div class="financing-sources-header">
+                                <span>Fontes de investimento</span>
+                                <button type="button" id="addFinancingSourceBtn" class="financing-secondary-button">+ Fonte</button>
+                            </div>
+                            <div id="financingSourcesContainer" class="financing-sources-container"></div>
+                        </div>
+                        <div class="financing-actions">
+                            <button type="button" id="calculateFinancingBtn" class="financing-primary-button">Calcular parcelas</button>
+                        </div>
+                    </form>
+                    <div id="financingResult" class="financing-result" data-help="Resumo com valores estimados e divisão das parcelas por fonte."></div>
+                </div>
+            </div>
+        </div>
         <div class="mermaid-container-wrapper">
-            <div id="mermaidContainer"><!-- DIAGRAM_PLACEHOLDER --></div>
-            
+            <div id="mermaidContainer" data-help="Espaço principal de visualização do fluxograma."><!-- DIAGRAM_PLACEHOLDER --></div>
+
             <!-- Unfold/Collapse Controls -->
             <div class="unfold-collapse-controls">
                 <button class="unfold-collapse-button" id="unfoldAllBtn" title="Expand All Subgraphs">
@@ -187,7 +227,7 @@
             </div>
         </div>
 
-        <div id="mermaidCode">
+        <div id="mermaidCode" data-help="Visualização do código Mermaid correspondente ao fluxograma.">
             <!-- Show code Button -->
             <div class="code-controls">
                 <button id="showCodeBtn">▼ Show MermaidCode

--- a/webview/styles.css
+++ b/webview/styles.css
@@ -626,6 +626,67 @@ body {
     color: white;
 }
 
+.has-help {
+    position: relative;
+}
+
+.has-help .help-trigger {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    border: none;
+    background: var(--vscode-button-background, #0e639c);
+    color: var(--vscode-button-foreground, #ffffff);
+    font-weight: 600;
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+    z-index: 5;
+}
+
+.has-help:hover .help-trigger,
+.has-help.help-open .help-trigger,
+.has-help .help-trigger:focus-visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(-2px);
+}
+
+.help-tooltip {
+    position: absolute;
+    top: 8px;
+    right: 32px;
+    max-width: 280px;
+    background: var(--vscode-editorWidget-background, #252526);
+    color: var(--vscode-editorWidget-foreground, #cccccc);
+    border: 1px solid var(--vscode-editorWidget-border, #454545);
+    border-radius: 6px;
+    padding: 8px 10px;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.4);
+    font-size: 12px;
+    line-height: 1.4;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-8px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 10;
+}
+
+.has-help .help-tooltip.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
 /* Button transitions */
 .control-button {
     transition: all 0.2s ease;
@@ -827,6 +888,164 @@ body {
     flex-direction: column;
     gap: 16px;
 }
+
+.financing-modal-content {
+    max-width: 540px;
+}
+
+.financing-description {
+    margin-bottom: 16px;
+    font-size: 13px;
+    color: var(--vscode-descriptionForeground, #a0a0a0);
+}
+
+.financing-form {
+    display: grid;
+    gap: 12px;
+}
+
+.financing-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.financing-field label {
+    font-size: 12px;
+    color: var(--vscode-foreground);
+}
+
+.financing-field input,
+.financing-source-row input {
+    background-color: var(--vscode-input-background, #3c3c3c);
+    border: 1px solid var(--vscode-input-border, #4f4f4f);
+    color: var(--vscode-input-foreground, #ffffff);
+    border-radius: 4px;
+    padding: 6px 8px;
+    font-family: var(--vscode-font-family);
+    font-size: 12px;
+}
+
+.financing-field input:focus,
+.financing-source-row input:focus {
+    outline: 1px solid var(--vscode-focusBorder, #007acc);
+}
+
+.financing-sources-card {
+    border: 1px solid var(--vscode-panel-border, #3c3c3c);
+    border-radius: 6px;
+    padding: 12px;
+    background: rgba(255, 255, 255, 0.02);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.financing-sources-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--vscode-foreground);
+}
+
+.financing-secondary-button {
+    background: transparent;
+    border: 1px dashed var(--vscode-button-border, #5a5a5a);
+    color: var(--vscode-button-foreground, #ffffff);
+    border-radius: 4px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.financing-secondary-button:hover {
+    border-style: solid;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.financing-sources-container {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.financing-source-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(120px, 160px) auto;
+    gap: 8px;
+    align-items: center;
+}
+
+.financing-remove-source {
+    background: transparent;
+    border: 1px solid var(--vscode-errorForeground, #f48771);
+    color: var(--vscode-errorForeground, #f48771);
+    border-radius: 4px;
+    padding: 4px 8px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.financing-remove-source:hover {
+    background: rgba(244, 135, 113, 0.1);
+}
+
+.financing-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.financing-primary-button {
+    background: var(--vscode-button-background, #0e639c);
+    color: var(--vscode-button-foreground, #ffffff);
+    border: none;
+    border-radius: 4px;
+    padding: 6px 12px;
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.financing-primary-button:hover {
+    background: var(--vscode-button-hoverBackground, #1177bb);
+}
+
+.financing-result {
+    margin-top: 12px;
+    border: 1px solid var(--vscode-panel-border, #3c3c3c);
+    border-radius: 6px;
+    padding: 12px;
+    background: rgba(0, 0, 0, 0.25);
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--vscode-foreground);
+}
+
+.financing-result.error {
+    border-color: var(--vscode-errorForeground, #f48771);
+    color: var(--vscode-errorForeground, #f48771);
+    background: rgba(244, 135, 113, 0.1);
+}
+
+.financing-result ul {
+    margin: 8px 0 0 0;
+    padding-left: 16px;
+}
+
+.financing-result li {
+    margin-bottom: 4px;
+}
+
+@media (max-width: 520px) {
+    .financing-source-row {
+        grid-template-columns: 1fr;
+    }
+
+    .financing-remove-source {
+        justify-self: flex-start;
+    }
+}
+
 
 .bug-report-options {
     display: flex;


### PR DESCRIPTION
## Summary
- normalize configuration imports to match the exported schema and ignore legacy summary data
- add contextual help overlays and Portuguese guidance across the webview, including the new financing simulator modal
- clarify saved diagram interactions and highlight that fontes represent contributions from different people

## Testing
- npm run compile

------
https://chatgpt.com/codex/tasks/task_e_68e2a65cb00483208bb8687827947c67