### PR TITLE
Add connection view flowchart tab and call hierarchy analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,20 @@
           "default": true,
           "description": "Process try/except/finally blocks"
         },
+        "flowchartMachine.connectionView.maxIncomingDepth": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 8,
+          "default": 3,
+          "description": "Maximum depth for discovering callers in the connection view"
+        },
+        "flowchartMachine.connectionView.maxOutgoingDepth": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 8,
+          "default": 4,
+          "description": "Maximum depth for discovering callees in the connection view"
+        },
         "flowchartMachine.storage.maxSavedFlowcharts": {
           "type": "number",
           "minimum": 1,

--- a/src/commands/generateFlowchart.ts
+++ b/src/commands/generateFlowchart.ts
@@ -3,16 +3,19 @@ import { PythonService } from '../services/pythonService';
 import { FileService } from '../services/fileService';
 import { WebviewManager } from '../webview/webviewManager';
 import { WhitelistService } from '../services/whitelistService';
+import { ConnectionViewService } from '../services/connectionViewService';
 
 export class GenerateFlowchartCommand {
   private context: vscode.ExtensionContext;
   private webviewManager: WebviewManager;
   private fileService: FileService;
+  private connectionService: ConnectionViewService;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.webviewManager = new WebviewManager(context);
     this.fileService = new FileService(context);
+    this.connectionService = new ConnectionViewService();
   }
 
   /**
@@ -169,13 +172,22 @@ export class GenerateFlowchartCommand {
           whitelistService.startSession();
 
           // Create the webview panel
+          const connectionView = await this.connectionService.createFromMetadata(filePath, output.metadata);
+          if (connectionView) {
+            output.metadata = {
+              ...output.metadata,
+              connectionView: connectionView.metadata
+            };
+          }
+
           this.webviewManager.createFlowchartWebview(
             output.mermaidCode,
             output.metadata,
             FileService.getBaseName(filePath),
             filePath,
             whitelistService,
-            null // processor is not available in TypeScript
+            null, // processor is not available in TypeScript
+            connectionView || undefined
           );
           resolve();
         } catch (error) {

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -20,6 +20,10 @@ export const DEFAULT_CONFIG: FlowchartConfig = {
       exceptions: true,
     },
   },
+  connectionView: {
+    maxIncomingDepth: 3,
+    maxOutgoingDepth: 4,
+  },
   storage: {
     saveFlowcharts: true,
     maxSavedFlowcharts: 50,
@@ -96,6 +100,20 @@ export const CONFIG_SCHEMA = {
     type: 'boolean',
     default: DEFAULT_CONFIG.nodes.processTypes.exceptions,
     description: 'Show exception handling in the flowchart',
+  },
+  'flowchartMachine.connectionView.maxIncomingDepth': {
+    type: 'number',
+    minimum: 0,
+    maximum: 8,
+    default: DEFAULT_CONFIG.connectionView.maxIncomingDepth,
+    description: 'Maximum depth for traversing callers of the selected function in connection view',
+  },
+  'flowchartMachine.connectionView.maxOutgoingDepth': {
+    type: 'number',
+    minimum: 0,
+    maximum: 8,
+    default: DEFAULT_CONFIG.connectionView.maxOutgoingDepth,
+    description: 'Maximum depth for traversing callees of the selected function in connection view',
   },
   'flowchartMachine.storage.saveFlowcharts': {
     type: 'boolean',

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -179,6 +179,10 @@ export class ConfigService {
           exceptions: config.get('nodes.processTypes.exceptions', DEFAULT_CONFIG.nodes.processTypes.exceptions),
         },
       },
+      connectionView: {
+        maxIncomingDepth: config.get('connectionView.maxIncomingDepth', DEFAULT_CONFIG.connectionView.maxIncomingDepth),
+        maxOutgoingDepth: config.get('connectionView.maxOutgoingDepth', DEFAULT_CONFIG.connectionView.maxOutgoingDepth),
+      },
       storage: {
         saveFlowcharts: true, // Default value, not configurable
         maxSavedFlowcharts: config.get('storage.maxSavedFlowcharts', DEFAULT_CONFIG.storage.maxSavedFlowcharts),

--- a/src/services/connectionViewService.ts
+++ b/src/services/connectionViewService.ts
@@ -26,7 +26,68 @@ interface NodeInfo {
   fileLabel: string;
 }
 
+interface PythonSymbolInfo {
+  uri: vscode.Uri;
+  name: string;
+  className?: string;
+  signature: string;
+  range: vscode.Range;
+  callKeys: Set<string>;
+}
+
+interface PythonWorkspaceIndex {
+  byKey: Map<string, PythonSymbolInfo[]>;
+  byUri: Map<string, PythonSymbolInfo[]>;
+  callersByKey: Map<string, Set<PythonSymbolInfo>>;
+}
+
+const PYTHON_RESERVED_NAMES = new Set([
+  'and',
+  'as',
+  'assert',
+  'async',
+  'await',
+  'break',
+  'class',
+  'continue',
+  'def',
+  'del',
+  'elif',
+  'else',
+  'except',
+  'False',
+  'finally',
+  'for',
+  'from',
+  'global',
+  'if',
+  'import',
+  'in',
+  'is',
+  'lambda',
+  'None',
+  'nonlocal',
+  'not',
+  'or',
+  'pass',
+  'raise',
+  'return',
+  'True',
+  'try',
+  'while',
+  'with',
+  'yield',
+  'self',
+  'cls',
+  '__init__',
+  '__name__',
+  '__main__',
+  'super'
+]);
+
 export class ConnectionViewService {
+  private pythonIndexPromise: Promise<PythonWorkspaceIndex | null> | null = null;
+
   private getDepthConfig(): { incomingDepth: number; outgoingDepth: number } {
     const config = vscode.workspace.getConfiguration('flowchartMachine');
     const incoming = config.get<number>('connectionView.maxIncomingDepth', 3) ?? 3;
@@ -82,11 +143,11 @@ export class ConnectionViewService {
       );
     } catch (error) {
       console.warn('Connection view: prepareCallHierarchy failed.', error);
-      return this.createFallbackResult('Call hierarchy is not supported for this symbol.');
+      return this.buildFallbackConnectionView(document, entry, incomingDepth, outgoingDepth);
     }
 
     if (!rootItems || rootItems.length === 0) {
-      return this.createFallbackResult('No call hierarchy information is available for this symbol.');
+      return this.buildFallbackConnectionView(document, entry, incomingDepth, outgoingDepth);
     }
 
     const rootItem = this.pickRootItem(rootItems, entry) ?? rootItems[0];
@@ -316,6 +377,10 @@ export class ConnectionViewService {
     return label.replace(/\"/g, '\'');
   }
 
+  private escapeForPlaceholder(label: string): string {
+    return label.replace(/\"/g, '\'').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  }
+
   private pickRootItem(items: vscode.CallHierarchyItem[], entry: EntrySelection): vscode.CallHierarchyItem | undefined {
     if (!entry) {
       return items[0];
@@ -406,5 +471,460 @@ export class ConnectionViewService {
     }
 
     return undefined;
+  }
+
+  private async buildFallbackConnectionView(
+    document: vscode.TextDocument,
+    entry: EntrySelection,
+    incomingDepth: number,
+    outgoingDepth: number
+  ): Promise<ConnectionViewResult> {
+    if (document.languageId !== 'python') {
+      return this.createFallbackResult('Call hierarchy is unavailable and Python fallback analysis cannot run for this language.');
+    }
+
+    const index = await this.getPythonIndex();
+    if (!index) {
+      return this.createFallbackResult('No Python files were found for connection analysis.');
+    }
+
+    const position = this.resolveEntryPosition(document, entry);
+    const symbol = this.findPythonSymbolForEntry(document, position, entry, index);
+
+    if (!symbol) {
+      return this.createFallbackResult('Unable to resolve the selected Python symbol for fallback analysis.');
+    }
+
+    const nodes = new Map<string, NodeInfo>();
+    const subgraphs = new Map<string, Set<string>>();
+    const edges = new Set<string>();
+
+    const rootKey = this.getPythonSymbolKey(symbol);
+    this.ensurePythonNode(symbol, nodes, subgraphs, true);
+
+    const outgoingVisited = new Set<string>([rootKey]);
+    const incomingVisited = new Set<string>([rootKey]);
+
+    await this.collectPythonOutgoing(symbol, 0, outgoingDepth, index, nodes, subgraphs, edges, outgoingVisited);
+    await this.collectPythonIncoming(symbol, 0, incomingDepth, index, nodes, subgraphs, edges, incomingVisited);
+
+    const diagram = this.buildDiagram(subgraphs, edges);
+    const hasData = edges.size > 0 || nodes.size > 1;
+
+    return {
+      diagram,
+      metadata: {
+        hasData,
+        nodes: nodes.size,
+        edges: edges.size,
+        incomingDepth,
+        outgoingDepth,
+        message: hasData ? undefined : 'No callers or callees were found for the selected symbol.'
+      }
+    };
+  }
+
+  private async getPythonIndex(): Promise<PythonWorkspaceIndex | null> {
+    if (this.pythonIndexPromise) {
+      return this.pythonIndexPromise;
+    }
+
+    this.pythonIndexPromise = this.createPythonIndex();
+    return this.pythonIndexPromise;
+  }
+
+  private async createPythonIndex(): Promise<PythonWorkspaceIndex | null> {
+    const folders = vscode.workspace.workspaceFolders;
+    if (!folders || folders.length === 0) {
+      return null;
+    }
+
+    const files = await vscode.workspace.findFiles(
+      '**/*.py',
+      '{**/.venv/**,**/venv/**,**/__pycache__/**,**/site-packages/**,**/node_modules/**,**/.git/**}',
+      2000
+    );
+
+    if (files.length === 0) {
+      return null;
+    }
+
+    const byKey = new Map<string, PythonSymbolInfo[]>();
+    const byUri = new Map<string, PythonSymbolInfo[]>();
+    const callersByKey = new Map<string, Set<PythonSymbolInfo>>();
+
+    for (const file of files) {
+      let document: vscode.TextDocument;
+      try {
+        document = await vscode.workspace.openTextDocument(file);
+      } catch (error) {
+        console.warn('Connection view fallback: failed to open Python file', file.toString(), error);
+        continue;
+      }
+
+      const symbols = this.parsePythonDocument(document);
+      if (!symbols.length) {
+        continue;
+      }
+
+      byUri.set(file.toString(), symbols);
+
+      for (const symbol of symbols) {
+        const keys = this.getPythonSymbolKeys(symbol);
+        for (const key of keys) {
+          if (!byKey.has(key)) {
+            byKey.set(key, []);
+          }
+          byKey.get(key)!.push(symbol);
+        }
+
+        for (const callKey of symbol.callKeys) {
+          if (!callersByKey.has(callKey)) {
+            callersByKey.set(callKey, new Set<PythonSymbolInfo>());
+          }
+          callersByKey.get(callKey)!.add(symbol);
+        }
+      }
+    }
+
+    return {
+      byKey,
+      byUri,
+      callersByKey
+    };
+  }
+
+  private parsePythonDocument(document: vscode.TextDocument): PythonSymbolInfo[] {
+    const text = document.getText();
+    const lines = text.split(/\r?\n/);
+    const symbols: PythonSymbolInfo[] = [];
+    const classStack: { name: string; indent: number }[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
+      const trimmed = line.trim();
+
+      if (!trimmed) {
+        continue;
+      }
+
+      const indent = line.length - line.trimStart().length;
+
+      while (classStack.length && indent <= classStack[classStack.length - 1].indent) {
+        classStack.pop();
+      }
+
+      if (trimmed.startsWith('@')) {
+        continue;
+      }
+
+      const classMatch = trimmed.match(/^class\s+([A-Za-z_][\w]*)/);
+      if (classMatch) {
+        const className = classMatch[1];
+        classStack.push({ name: className, indent });
+        continue;
+      }
+
+      const funcMatch = trimmed.match(/^def\s+([A-Za-z_][\w]*)\s*\(([^)]*)\)/);
+      if (!funcMatch) {
+        continue;
+      }
+
+      const name = funcMatch[1];
+      const params = funcMatch[2]?.trim() ?? '';
+      const classContext = classStack[classStack.length - 1];
+      const signature = params.length > 0 ? `${name}(${params})` : `${name}()`;
+
+      const endLine = this.findPythonBlockEnd(lines, i, indent);
+      const range = new vscode.Range(i, 0, endLine, lines[endLine]?.length ?? 0);
+      const body = lines.slice(i + 1, endLine + 1).join('\n');
+
+      const callKeys = this.extractPythonCallKeys(body);
+
+      const symbol: PythonSymbolInfo = {
+        uri: document.uri,
+        name,
+        className: classContext ? classContext.name : undefined,
+        signature,
+        range,
+        callKeys
+      };
+
+      symbols.push(symbol);
+    }
+
+    return symbols;
+  }
+
+  private findPythonBlockEnd(lines: string[], startLine: number, baseIndent: number): number {
+    let endLine = startLine;
+
+    for (let i = startLine + 1; i < lines.length; i++) {
+      const line = lines[i];
+      const trimmed = line.trim();
+
+      if (!trimmed) {
+        continue;
+      }
+
+      const indent = line.length - line.trimStart().length;
+      if (indent <= baseIndent) {
+        break;
+      }
+
+      endLine = i;
+    }
+
+    return endLine;
+  }
+
+  private extractPythonCallKeys(body: string): Set<string> {
+    const result = new Set<string>();
+    if (!body) {
+      return result;
+    }
+
+    const callRegex = /([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)\s*\(/g;
+    let match: RegExpExecArray | null;
+
+    while ((match = callRegex.exec(body))) {
+      const expression = match[1];
+      if (!expression) {
+        continue;
+      }
+
+      const parts = expression.split('.');
+      const method = parts[parts.length - 1];
+      if (!method || PYTHON_RESERVED_NAMES.has(method)) {
+        continue;
+      }
+
+      result.add(`function:${method}`);
+
+      if (parts.length >= 2) {
+        const qualifier = parts[parts.length - 2];
+        if (qualifier && !PYTHON_RESERVED_NAMES.has(qualifier)) {
+          result.add(`method:${qualifier}.${method}`);
+        }
+      }
+    }
+
+    return result;
+  }
+
+  private getPythonSymbolKeys(symbol: PythonSymbolInfo): string[] {
+    const keys = [`function:${symbol.name}`];
+    if (symbol.className) {
+      keys.unshift(`method:${symbol.className}.${symbol.name}`);
+    }
+    return keys;
+  }
+
+  private getPythonSymbolKey(symbol: PythonSymbolInfo): string {
+    return `${symbol.uri.toString()}#${symbol.className ?? ''}#${symbol.name}#${symbol.range.start.line}`;
+  }
+
+  private findPythonSymbolForEntry(
+    document: vscode.TextDocument,
+    position: vscode.Position | undefined,
+    entry: EntrySelection,
+    index: PythonWorkspaceIndex
+  ): PythonSymbolInfo | undefined {
+    const uriKey = document.uri.toString();
+    const symbolsInFile = index.byUri.get(uriKey) ?? [];
+
+    if (position) {
+      const symbolAtPosition = symbolsInFile.find(sym => sym.range.contains(position));
+      if (symbolAtPosition) {
+        return symbolAtPosition;
+      }
+    }
+
+    const keyCandidates: string[] = [];
+    if (entry.class && entry.name) {
+      keyCandidates.push(`method:${entry.class}.${entry.name}`);
+    }
+    if (entry.name) {
+      keyCandidates.push(`function:${entry.name}`);
+    }
+
+    for (const key of keyCandidates) {
+      const candidates = index.byKey.get(key);
+      if (candidates && candidates.length) {
+        const inSameFile = candidates.find(candidate => candidate.uri.toString() === uriKey);
+        return inSameFile ?? candidates[0];
+      }
+    }
+
+    if (symbolsInFile.length === 1) {
+      return symbolsInFile[0];
+    }
+
+    if (position) {
+      const nearest = symbolsInFile.find(sym => sym.range.start.line >= position.line);
+      if (nearest) {
+        return nearest;
+      }
+    }
+
+    return undefined;
+  }
+
+  private ensurePythonNode(
+    symbol: PythonSymbolInfo,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    isRoot: boolean = false
+  ): NodeInfo {
+    const key = this.getPythonSymbolKey(symbol);
+    const existing = nodes.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const id = `node${nodes.size + 1}`;
+    const labelParts: string[] = [];
+    const qualifiedName = symbol.className ? `${symbol.className}.${symbol.name}` : symbol.name;
+    labelParts.push(this.escapeLabel(qualifiedName));
+    if (symbol.signature) {
+      labelParts.push(this.escapeLabel(symbol.signature));
+    }
+    labelParts.push(`Line ${symbol.range.start.line + 1}`);
+    if (isRoot) {
+      labelParts.push('Selected');
+    }
+
+    const label = labelParts.join('<br/>');
+    const definition = isRoot ? `${id}((\"${label}\"))` : `${id}[\"${label}\"]`;
+    const fileLabel = this.getFileLabel(symbol.uri);
+
+    if (!subgraphs.has(fileLabel)) {
+      subgraphs.set(fileLabel, new Set<string>());
+    }
+    subgraphs.get(fileLabel)!.add(definition);
+
+    const info: NodeInfo = { id, definition, fileLabel };
+    nodes.set(key, info);
+    return info;
+  }
+
+  private ensurePythonPlaceholderNode(
+    callKey: string,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>
+  ): NodeInfo {
+    const key = `placeholder:${callKey}`;
+    const existing = nodes.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const id = `node${nodes.size + 1}`;
+    const label = this.escapeForPlaceholder(this.describeCallKey(callKey));
+    const definition = `${id}[\"${label}\"]`;
+    const placeholderGroup = 'Unresolved references';
+    if (!subgraphs.has(placeholderGroup)) {
+      subgraphs.set(placeholderGroup, new Set<string>());
+    }
+    subgraphs.get(placeholderGroup)!.add(definition);
+
+    const info: NodeInfo = { id, definition, fileLabel: placeholderGroup };
+    nodes.set(key, info);
+    return info;
+  }
+
+  private describeCallKey(callKey: string): string {
+    if (callKey.startsWith('method:')) {
+      const [, name] = callKey.split(':');
+      return `${name} (unresolved)`;
+    }
+    if (callKey.startsWith('function:')) {
+      const [, name] = callKey.split(':');
+      return `${name} (unresolved)`;
+    }
+    return `Unresolved (${callKey})`;
+  }
+
+  private async collectPythonOutgoing(
+    symbol: PythonSymbolInfo,
+    depth: number,
+    maxDepth: number,
+    index: PythonWorkspaceIndex,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    edges: Set<string>,
+    visited: Set<string>
+  ): Promise<void> {
+    if (depth >= maxDepth) {
+      return;
+    }
+
+    const sourceInfo = this.ensurePythonNode(symbol, nodes, subgraphs);
+    const callKeys = Array.from(symbol.callKeys);
+
+    for (const callKey of callKeys) {
+      const targets = index.byKey.get(callKey);
+
+      if (!targets || targets.length === 0) {
+        const placeholder = this.ensurePythonPlaceholderNode(callKey, nodes, subgraphs);
+        edges.add(`  ${sourceInfo.id} --> ${placeholder.id}`);
+        continue;
+      }
+
+      for (const target of targets) {
+        const key = this.getPythonSymbolKey(target);
+        const targetInfo = this.ensurePythonNode(target, nodes, subgraphs);
+        edges.add(`  ${sourceInfo.id} --> ${targetInfo.id}`);
+
+        if (!visited.has(key)) {
+          visited.add(key);
+          await this.collectPythonOutgoing(target, depth + 1, maxDepth, index, nodes, subgraphs, edges, visited);
+        }
+      }
+    }
+  }
+
+  private async collectPythonIncoming(
+    symbol: PythonSymbolInfo,
+    depth: number,
+    maxDepth: number,
+    index: PythonWorkspaceIndex,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    edges: Set<string>,
+    visited: Set<string>
+  ): Promise<void> {
+    if (depth >= maxDepth) {
+      return;
+    }
+
+    const targetInfo = this.ensurePythonNode(symbol, nodes, subgraphs);
+    const symbolKeys = this.getPythonSymbolKeys(symbol);
+    const callers = new Set<PythonSymbolInfo>();
+
+    for (const key of symbolKeys) {
+      const found = index.callersByKey.get(key);
+      if (!found) {
+        continue;
+      }
+      for (const caller of found) {
+        callers.add(caller);
+      }
+    }
+
+    if (callers.size === 0) {
+      return;
+    }
+
+    for (const caller of callers) {
+      const callerKey = this.getPythonSymbolKey(caller);
+      const callerInfo = this.ensurePythonNode(caller, nodes, subgraphs);
+      edges.add(`  ${callerInfo.id} --> ${targetInfo.id}`);
+
+      if (!visited.has(callerKey)) {
+        visited.add(callerKey);
+        await this.collectPythonIncoming(caller, depth + 1, maxDepth, index, nodes, subgraphs, edges, visited);
+      }
+    }
   }
 }

--- a/src/services/connectionViewService.ts
+++ b/src/services/connectionViewService.ts
@@ -1,0 +1,410 @@
+import * as vscode from 'vscode';
+
+export interface ConnectionViewResult {
+  diagram: string;
+  metadata: {
+    hasData: boolean;
+    nodes: number;
+    edges: number;
+    incomingDepth: number;
+    outgoingDepth: number;
+    message?: string;
+  };
+}
+
+interface EntrySelection {
+  type?: string;
+  name?: string;
+  class?: string;
+  line_offset?: Record<string, number>;
+  lineOffset?: Record<string, number>;
+}
+
+interface NodeInfo {
+  id: string;
+  definition: string;
+  fileLabel: string;
+}
+
+export class ConnectionViewService {
+  private getDepthConfig(): { incomingDepth: number; outgoingDepth: number } {
+    const config = vscode.workspace.getConfiguration('flowchartMachine');
+    const incoming = config.get<number>('connectionView.maxIncomingDepth', 3) ?? 3;
+    const outgoing = config.get<number>('connectionView.maxOutgoingDepth', 4) ?? 4;
+    const sanitize = (value: number) => {
+      if (Number.isNaN(value) || value < 0) {
+        return 0;
+      }
+      if (value > 8) {
+        return 8;
+      }
+      return Math.floor(value);
+    };
+    return {
+      incomingDepth: sanitize(incoming),
+      outgoingDepth: sanitize(outgoing)
+    };
+  }
+
+  async createFromMetadata(filePath: string, metadata: any): Promise<ConnectionViewResult | null> {
+    if (!metadata || !metadata.entry_selection) {
+      return null;
+    }
+
+    const entry: EntrySelection = metadata.entry_selection;
+    if (!entry || entry.type === 'file') {
+      return null;
+    }
+
+    try {
+      const document = await vscode.workspace.openTextDocument(vscode.Uri.file(filePath));
+      return await this.buildConnectionView(document, entry);
+    } catch (error) {
+      console.warn('Connection view: unable to open document for connection analysis.', error);
+      return this.createFallbackResult('Unable to open file for connection analysis.');
+    }
+  }
+
+  private async buildConnectionView(document: vscode.TextDocument, entry: EntrySelection): Promise<ConnectionViewResult> {
+    const position = this.resolveEntryPosition(document, entry);
+    if (!position) {
+      return this.createFallbackResult('Unable to locate the selected symbol in the document.');
+    }
+
+    const { incomingDepth, outgoingDepth } = this.getDepthConfig();
+
+    let rootItems: vscode.CallHierarchyItem[] | undefined;
+    try {
+      rootItems = await vscode.commands.executeCommand<vscode.CallHierarchyItem[]>(
+        'vscode.prepareCallHierarchy',
+        document.uri,
+        position
+      );
+    } catch (error) {
+      console.warn('Connection view: prepareCallHierarchy failed.', error);
+      return this.createFallbackResult('Call hierarchy is not supported for this symbol.');
+    }
+
+    if (!rootItems || rootItems.length === 0) {
+      return this.createFallbackResult('No call hierarchy information is available for this symbol.');
+    }
+
+    const rootItem = this.pickRootItem(rootItems, entry) ?? rootItems[0];
+    const nodes = new Map<string, NodeInfo>();
+    const subgraphs = new Map<string, Set<string>>();
+    const edges = new Set<string>();
+
+    this.ensureNode(rootItem, nodes, subgraphs, true);
+    const outgoingVisited = new Set<string>([this.getItemKey(rootItem)]);
+    const incomingVisited = new Set<string>([this.getItemKey(rootItem)]);
+
+    await this.collectOutgoing(rootItem, 0, outgoingDepth, nodes, subgraphs, edges, outgoingVisited);
+    await this.collectIncoming(rootItem, 0, incomingDepth, nodes, subgraphs, edges, incomingVisited);
+
+    const diagram = this.buildDiagram(subgraphs, edges);
+    const hasData = edges.size > 0 || nodes.size > 1;
+
+    return {
+      diagram,
+      metadata: {
+        hasData,
+        nodes: nodes.size,
+        edges: edges.size,
+        incomingDepth,
+        outgoingDepth,
+        message: hasData ? undefined : 'No callers or callees were found for the selected symbol.'
+      }
+    };
+  }
+
+  private createFallbackResult(message: string): ConnectionViewResult {
+    const diagram = this.createPlaceholderDiagram(message);
+    return {
+      diagram,
+      metadata: {
+        hasData: false,
+        nodes: 1,
+        edges: 0,
+        incomingDepth: 0,
+        outgoingDepth: 0,
+        message
+      }
+    };
+  }
+
+  private createPlaceholderDiagram(message: string): string {
+    const escaped = this.escapeLabel(message);
+    return `graph TD\n    placeholder[\"${escaped}\"]`;
+  }
+
+  private async collectOutgoing(
+    item: vscode.CallHierarchyItem,
+    depth: number,
+    maxDepth: number,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    edges: Set<string>,
+    visited: Set<string>
+  ): Promise<void> {
+    if (depth >= maxDepth) {
+      return;
+    }
+
+    let calls: vscode.CallHierarchyOutgoingCall[] | undefined;
+    try {
+      calls = await vscode.commands.executeCommand<vscode.CallHierarchyOutgoingCall[]>(
+        'vscode.provideCallHierarchyOutgoingCalls',
+        item
+      );
+    } catch (error) {
+      console.warn('Connection view: provideCallHierarchyOutgoingCalls failed.', error);
+      return;
+    }
+
+    if (!calls || calls.length === 0) {
+      return;
+    }
+
+    const sourceId = nodes.get(this.getItemKey(item))?.id;
+    if (!sourceId) {
+      return;
+    }
+
+    for (const call of calls) {
+      const target = call.to;
+      const key = this.getItemKey(target);
+      const targetInfo = this.ensureNode(target, nodes, subgraphs);
+      edges.add(`  ${sourceId} --> ${targetInfo.id}`);
+
+      if (!visited.has(key)) {
+        visited.add(key);
+        await this.collectOutgoing(target, depth + 1, maxDepth, nodes, subgraphs, edges, visited);
+      }
+    }
+  }
+
+  private async collectIncoming(
+    item: vscode.CallHierarchyItem,
+    depth: number,
+    maxDepth: number,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    edges: Set<string>,
+    visited: Set<string>
+  ): Promise<void> {
+    if (depth >= maxDepth) {
+      return;
+    }
+
+    let calls: vscode.CallHierarchyIncomingCall[] | undefined;
+    try {
+      calls = await vscode.commands.executeCommand<vscode.CallHierarchyIncomingCall[]>(
+        'vscode.provideCallHierarchyIncomingCalls',
+        item
+      );
+    } catch (error) {
+      console.warn('Connection view: provideCallHierarchyIncomingCalls failed.', error);
+      return;
+    }
+
+    if (!calls || calls.length === 0) {
+      return;
+    }
+
+    const targetId = nodes.get(this.getItemKey(item))?.id;
+    if (!targetId) {
+      return;
+    }
+
+    for (const call of calls) {
+      const source = call.from;
+      const key = this.getItemKey(source);
+      const sourceInfo = this.ensureNode(source, nodes, subgraphs);
+      edges.add(`  ${sourceInfo.id} --> ${targetId}`);
+
+      if (!visited.has(key)) {
+        visited.add(key);
+        await this.collectIncoming(source, depth + 1, maxDepth, nodes, subgraphs, edges, visited);
+      }
+    }
+  }
+
+  private buildDiagram(subgraphs: Map<string, Set<string>>, edges: Set<string>): string {
+    const lines: string[] = ['graph TD'];
+
+    for (const [label, nodeDefinitions] of subgraphs) {
+      const escaped = this.escapeSubgraphLabel(label);
+      lines.push(`  subgraph \"${escaped}\"`);
+      for (const def of nodeDefinitions) {
+        lines.push(`    ${def}`);
+      }
+      lines.push('  end');
+    }
+
+    for (const edge of edges) {
+      lines.push(edge);
+    }
+
+    return lines.join('\n');
+  }
+
+  private ensureNode(
+    item: vscode.CallHierarchyItem,
+    nodes: Map<string, NodeInfo>,
+    subgraphs: Map<string, Set<string>>,
+    isRoot: boolean = false
+  ): NodeInfo {
+    const key = this.getItemKey(item);
+    const existing = nodes.get(key);
+    if (existing) {
+      return existing;
+    }
+
+    const id = `node${nodes.size + 1}`;
+    const label = this.buildNodeLabel(item, isRoot);
+    const definition = isRoot ? `${id}((\"${label}\"))` : `${id}[\"${label}\"]`;
+    const fileLabel = this.getFileLabel(item.uri);
+
+    if (!subgraphs.has(fileLabel)) {
+      subgraphs.set(fileLabel, new Set<string>());
+    }
+    subgraphs.get(fileLabel)!.add(definition);
+
+    const info: NodeInfo = { id, definition, fileLabel };
+    nodes.set(key, info);
+    return info;
+  }
+
+  private buildNodeLabel(item: vscode.CallHierarchyItem, isRoot: boolean): string {
+    const parts: string[] = [];
+    if (item.name) {
+      parts.push(this.escapeLabel(item.name));
+    }
+    if (item.detail) {
+      parts.push(this.escapeLabel(item.detail));
+    }
+
+    const line = item.selectionRange?.start.line ?? item.range?.start.line;
+    if (typeof line === 'number') {
+      parts.push(`Line ${line + 1}`);
+    }
+
+    if (isRoot) {
+      parts.push('Selected');
+    }
+
+    return parts.join('<br/>');
+  }
+
+  private getFileLabel(uri: vscode.Uri): string {
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+    const relative = workspaceFolder ? vscode.workspace.asRelativePath(uri, false) : uri.fsPath;
+    return relative.replace(/\\/g, '/');
+  }
+
+  private getItemKey(item: vscode.CallHierarchyItem): string {
+    const range = item.selectionRange ?? item.range;
+    const line = range?.start.line ?? 0;
+    return `${item.uri.toString()}#${item.name}#${line}`;
+  }
+
+  private escapeLabel(label: string): string {
+    return label.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\"/g, '\'');
+  }
+
+  private escapeSubgraphLabel(label: string): string {
+    return label.replace(/\"/g, '\'');
+  }
+
+  private pickRootItem(items: vscode.CallHierarchyItem[], entry: EntrySelection): vscode.CallHierarchyItem | undefined {
+    if (!entry) {
+      return items[0];
+    }
+
+    const name = entry.name;
+    const className = entry.class;
+
+    if (!name && !className) {
+      return items[0];
+    }
+
+    const matches = items.filter(item => {
+      if (name && item.name === name) {
+        if (!className) {
+          return true;
+        }
+        return item.detail?.includes(className) ?? false;
+      }
+      if (!name && className && item.name === className) {
+        return true;
+      }
+      return false;
+    });
+
+    return matches[0] ?? items[0];
+  }
+
+  private resolveEntryPosition(document: vscode.TextDocument, entry: EntrySelection): vscode.Position | undefined {
+    const offsets = entry.line_offset ?? entry.lineOffset ?? {};
+    const key = this.getOffsetKey(entry);
+
+    if (key && offsets && typeof offsets[key] === 'number') {
+      const line = offsets[key];
+      if (!Number.isNaN(line)) {
+        return new vscode.Position(Math.max(0, line - 1), 0);
+      }
+    }
+
+    return this.findPositionBySearch(document, entry);
+  }
+
+  private getOffsetKey(entry: EntrySelection): string | undefined {
+    if (entry.type === 'function' && entry.name) {
+      return entry.name;
+    }
+    if (entry.type === 'class') {
+      if (entry.class && entry.name) {
+        return `${entry.class}.${entry.name}`;
+      }
+      if (entry.class) {
+        return entry.class;
+      }
+    }
+    return undefined;
+  }
+
+  private findPositionBySearch(document: vscode.TextDocument, entry: EntrySelection): vscode.Position | undefined {
+    const text = document.getText();
+    if (entry.type === 'function' && entry.name) {
+      const regex = new RegExp(`\\bdef\\s+${entry.name}\\s*\\(`, 'g');
+      const match = regex.exec(text);
+      if (match) {
+        return document.positionAt(match.index);
+      }
+    }
+
+    if (entry.type === 'class') {
+      if (entry.class && entry.name) {
+        const regex = new RegExp(`\\bdef\\s+${entry.name}\\s*\\(`, 'g');
+        let match: RegExpExecArray | null;
+        while ((match = regex.exec(text))) {
+          const pos = document.positionAt(match.index);
+          const classRegex = new RegExp(`\\bclass\\s+${entry.class}\\b`, 'g');
+          const classMatch = classRegex.exec(text.slice(0, match.index));
+          if (classMatch) {
+            return pos;
+          }
+        }
+      }
+      if (entry.class) {
+        const regex = new RegExp(`\\bclass\\s+${entry.class}\\b`, 'g');
+        const match = regex.exec(text);
+        if (match) {
+          return document.positionAt(match.index);
+        }
+      }
+    }
+
+    return undefined;
+  }
+}

--- a/src/services/connectionViewService.ts
+++ b/src/services/connectionViewService.ts
@@ -392,10 +392,10 @@ export class ConnectionViewService {
     const hasCaller = roles.has('caller');
     const hasCallee = roles.has('callee');
     if (hasCaller && !hasCallee) {
-      return '#d6efff';
+      return '#295673';
     }
     if (hasCallee && !hasCaller) {
-      return '#d4f7d4';
+      return '#2e572e';
     }
     return null;
   }
@@ -435,15 +435,6 @@ export class ConnectionViewService {
     }
     if (item.detail) {
       parts.push(this.escapeLabel(item.detail));
-    }
-
-    const line = item.selectionRange?.start.line ?? item.range?.start.line;
-    if (typeof line === 'number') {
-      parts.push(`Line ${line + 1}`);
-    }
-
-    if (isRoot) {
-      parts.push('Selected');
     }
 
     return parts.join('<br/>');
@@ -959,13 +950,10 @@ export class ConnectionViewService {
     const id = `node${nodes.size + 1}`;
     const labelParts: string[] = [];
     const qualifiedName = symbol.className ? `${symbol.className}.${symbol.name}` : symbol.name;
-    labelParts.push(this.escapeLabel(qualifiedName));
     if (symbol.signature) {
       labelParts.push(this.escapeLabel(symbol.signature));
-    }
-    labelParts.push(`Line ${symbol.range.start.line + 1}`);
-    if (role === 'root') {
-      labelParts.push('Selected');
+    } else {
+      labelParts.push(this.escapeLabel(qualifiedName));
     }
 
     const label = labelParts.join('<br/>');

--- a/src/test/connection_view_fallback.test.ts
+++ b/src/test/connection_view_fallback.test.ts
@@ -1,0 +1,90 @@
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+import { ConnectionViewService } from '../services/connectionViewService';
+
+suite('Connection View Fallback', () => {
+  const testWorkspace = path.join(__dirname, 'connection-workspace');
+  const sourceDir = path.join(__dirname, 'python_files', 'connection_fallback');
+  let originalFolders: readonly vscode.WorkspaceFolder[] | undefined;
+
+  suiteSetup(async () => {
+    if (fs.existsSync(testWorkspace)) {
+      fs.rmSync(testWorkspace, { recursive: true, force: true });
+    }
+    fs.mkdirSync(testWorkspace, { recursive: true });
+
+    for (const entry of fs.readdirSync(sourceDir)) {
+      const srcPath = path.join(sourceDir, entry);
+      const destPath = path.join(testWorkspace, entry);
+      fs.copyFileSync(srcPath, destPath);
+    }
+
+    originalFolders = vscode.workspace.workspaceFolders;
+    const folderUri = vscode.Uri.file(testWorkspace);
+    vscode.workspace.updateWorkspaceFolders(0, originalFolders ? originalFolders.length : 0, {
+      uri: folderUri,
+      name: 'ConnectionFallback'
+    });
+
+    // Allow the workspace change to propagate
+    await new Promise(resolve => setTimeout(resolve, 250));
+  });
+
+  suiteTeardown(() => {
+    const currentCount = vscode.workspace.workspaceFolders?.length ?? 0;
+    vscode.workspace.updateWorkspaceFolders(0, currentCount);
+
+    if (originalFolders && originalFolders.length > 0) {
+      vscode.workspace.updateWorkspaceFolders(0, 0, ...originalFolders.map(folder => ({ uri: folder.uri, name: folder.name })));
+    }
+
+    if (fs.existsSync(testWorkspace)) {
+      fs.rmSync(testWorkspace, { recursive: true, force: true });
+    }
+  });
+
+  test('builds diagram when call hierarchy is unavailable', async () => {
+    const service = new ConnectionViewService();
+    const mainPath = path.join(testWorkspace, 'main.py');
+    const document = await vscode.workspace.openTextDocument(mainPath);
+    await vscode.window.showTextDocument(document);
+
+    const lines = document.getText().split(/\r?\n/);
+    const startLineIndex = lines.findIndex(line => line.includes('def start('));
+    assert.ok(startLineIndex >= 0, 'start function should exist in the test file');
+
+    const metadata = {
+      entry_selection: {
+        type: 'function',
+        name: 'start',
+        line_offset: { start: startLineIndex + 1 }
+      }
+    };
+
+    const originalExecute = vscode.commands.executeCommand;
+    (vscode.commands.executeCommand as any) = async (command: string, ...args: any[]) => {
+      if (
+        command === 'vscode.prepareCallHierarchy' ||
+        command === 'vscode.provideCallHierarchyOutgoingCalls' ||
+        command === 'vscode.provideCallHierarchyIncomingCalls'
+      ) {
+        throw new Error('Call hierarchy unavailable');
+      }
+      return originalExecute.call(vscode.commands, command, ...args);
+    };
+
+    try {
+      const result = await service.createFromMetadata(mainPath, metadata);
+      assert.ok(result, 'Result should not be null');
+      assert.ok(result?.metadata.hasData, 'Fallback should produce data');
+      assert.ok(result?.diagram.includes('main.py'));
+      assert.ok(result?.diagram.includes('helper.py'));
+      assert.ok(result?.diagram.includes('caller.py'));
+    } finally {
+      (vscode.commands.executeCommand as any) = originalExecute;
+    }
+  });
+});

--- a/src/test/connection_view_fallback.test.ts
+++ b/src/test/connection_view_fallback.test.ts
@@ -90,11 +90,11 @@ suite('Connection View Fallback', () => {
       assert.ok(!diagram.includes('Unresolved'), 'Diagram should not include unresolved references');
       assert.ok(!diagram.includes('print'), 'Built-in calls should be filtered out');
       assert.ok(
-        diagram.includes('#d6efff'),
+        diagram.includes('#295673'),
         'Caller subgraphs should be styled with light blue'
       );
       assert.ok(
-        diagram.includes('#d4f7d4'),
+        diagram.includes('#2e572e'),
         'Callee subgraphs should be styled with light green'
       );
     } finally {

--- a/src/test/connection_view_fallback.test.ts
+++ b/src/test/connection_view_fallback.test.ts
@@ -80,9 +80,23 @@ suite('Connection View Fallback', () => {
       const result = await service.createFromMetadata(mainPath, metadata);
       assert.ok(result, 'Result should not be null');
       assert.ok(result?.metadata.hasData, 'Fallback should produce data');
-      assert.ok(result?.diagram.includes('main.py'));
-      assert.ok(result?.diagram.includes('helper.py'));
-      assert.ok(result?.diagram.includes('caller.py'));
+
+      const diagram = result!.diagram;
+
+      assert.ok(diagram.startsWith('graph LR'), 'Diagram should render left-to-right');
+      assert.ok(diagram.includes('main.py'));
+      assert.ok(diagram.includes('helper.py'));
+      assert.ok(diagram.includes('caller.py'));
+      assert.ok(!diagram.includes('Unresolved'), 'Diagram should not include unresolved references');
+      assert.ok(!diagram.includes('print'), 'Built-in calls should be filtered out');
+      assert.ok(
+        diagram.includes('#d6efff'),
+        'Caller subgraphs should be styled with light blue'
+      );
+      assert.ok(
+        diagram.includes('#d4f7d4'),
+        'Callee subgraphs should be styled with light green'
+      );
     } finally {
       (vscode.commands.executeCommand as any) = originalExecute;
     }

--- a/src/test/python_files/connection_fallback/caller.py
+++ b/src/test/python_files/connection_fallback/caller.py
@@ -1,0 +1,5 @@
+from main import start
+
+
+def call_start():
+    start()

--- a/src/test/python_files/connection_fallback/helper.py
+++ b/src/test/python_files/connection_fallback/helper.py
@@ -1,0 +1,10 @@
+from helper_inner import helper_inner_func
+
+
+def helper_func():
+    helper_inner_func()
+
+
+class Worker:
+    def process(self):
+        helper_inner_func()

--- a/src/test/python_files/connection_fallback/helper_inner.py
+++ b/src/test/python_files/connection_fallback/helper_inner.py
@@ -1,0 +1,3 @@
+
+def helper_inner_func():
+    return 'inner'

--- a/src/test/python_files/connection_fallback/main.py
+++ b/src/test/python_files/connection_fallback/main.py
@@ -1,0 +1,12 @@
+from helper import helper_func
+from caller import call_start
+
+
+def start():
+    helper_func()
+    local()
+    call_start()
+
+
+def local():
+    return 'done'

--- a/src/test/python_files/connection_fallback/main.py
+++ b/src/test/python_files/connection_fallback/main.py
@@ -6,6 +6,7 @@ def start():
     helper_func()
     local()
     call_start()
+    print('ready')
 
 
 def local():

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -14,6 +14,7 @@ export function run(): Promise<void> {
   return new Promise((resolve, reject) => {
     try {
       mocha.addFile(path.resolve(testsRoot, 'generate_command.test.ts'));
+      mocha.addFile(path.resolve(testsRoot, 'connection_view_fallback.test.ts'));
 
       // Run the mocha test
       mocha.run((failures: any) => {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,6 +7,8 @@ export interface FlowchartConfig {
   general: GeneralConfig;
   /** Node processing configuration */
   nodes: NodeConfig;
+  /** Connection view configuration */
+  connectionView: ConnectionViewConfig;
   /** Storage and persistence settings */
   storage: StorageConfig;
   /** Visual appearance settings */
@@ -31,6 +33,11 @@ export interface NodeConfig {
     imports: boolean;
     exceptions: boolean;
   };
+}
+
+export interface ConnectionViewConfig {
+  maxIncomingDepth: number;
+  maxOutgoingDepth: number;
 }
 
 export interface StorageConfig {
@@ -134,5 +141,7 @@ export type ConfigurationKey =
   | 'nodes.processTypes.ifs'
   | 'nodes.processTypes.imports'
   | 'nodes.processTypes.exceptions'
+  | 'connectionView.maxIncomingDepth'
+  | 'connectionView.maxOutgoingDepth'
   | 'performance.maxNodes'
   | 'performance.timeout';

--- a/src/webview/webviewManager.ts
+++ b/src/webview/webviewManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs';
 import * as path from 'path';
 import { WebviewMessageHandler } from './messageHandler';
+import { ConnectionViewResult } from '../services/connectionViewService';
 
 export class WebviewManager {
   private context: vscode.ExtensionContext;
@@ -20,10 +21,11 @@ export class WebviewManager {
   createFlowchartWebview(
     mermaidCode: string,
     metadata: any,
-    fileName: string, 
+    fileName: string,
     originalFilePath?: string,
     whitelistService?: any,
-    processor?: any
+    processor?: any,
+    connectionView?: ConnectionViewResult
   ): vscode.WebviewPanel {
     // Store the original file path for regeneration
     this.originalFilePath = originalFilePath || 
@@ -91,7 +93,9 @@ export class WebviewManager {
         diagram: mermaidCode,
         metadata: metadata,
         whitelist: currentWhitelist,
-        forceCollapse: forceCollapseList
+        forceCollapse: forceCollapseList,
+        connectionDiagram: connectionView?.diagram,
+        connectionMetadata: connectionView?.metadata
       });
     }
 
@@ -137,6 +141,7 @@ export class WebviewManager {
       '{{mermaidInitUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'mermaid-init.js')).toString(),
       '{{zoomPanUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'zoom-pan.js')).toString(),
       '{{controlsUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'controls.js')).toString(),
+      '{{viewToggleUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'view-toggle.js')).toString(),
       '{{expandUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'expand.js')).toString(),
       '{{exportUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'export.js')).toString(),
       '{{messageHandlerUri}}': webview.asWebviewUri(vscode.Uri.joinPath(this.context.extensionUri, 'webview', 'message-handler.js')).toString(),

--- a/webview/index.html
+++ b/webview/index.html
@@ -157,7 +157,7 @@
         </div>
         <div class="mermaid-container-wrapper">
             <div id="mermaidContainer"><!-- DIAGRAM_PLACEHOLDER --></div>
-            
+
             <!-- Unfold/Collapse Controls -->
             <div class="unfold-collapse-controls">
                 <button class="unfold-collapse-button" id="unfoldAllBtn" title="Expand All Subgraphs">
@@ -169,7 +169,13 @@
                     <span class="button-text">Collapse All</span>
                 </button>
             </div>
-            
+
+            <div class="view-toggle-wrapper">
+                <button id="flowchartViewTab" class="view-tab active">Flowchart View</button>
+                <button id="connectionViewTab" class="view-tab">Connection View</button>
+                <span id="viewStatusMessage" class="view-status-message hidden"></span>
+            </div>
+
             <!-- Loading Message Container -->
             <div id="loadingContainer" class="loading-container">
                 <div class="loading-content">
@@ -219,6 +225,7 @@
     <script src="{{mermaidInitUri}}"></script>
     <script src="{{zoomPanUri}}"></script>
     <script src="{{controlsUri}}"></script>
+    <script src="{{viewToggleUri}}"></script>
     <script src="{{expandUri}}"></script>
     <script src="{{exportUri}}"></script>
     <script src="{{messageHandlerUri}}"></script>

--- a/webview/main.js
+++ b/webview/main.js
@@ -32,6 +32,10 @@ document.addEventListener("DOMContentLoaded", function () {
         initializeControls();
         initializeSavedDiagrams();
     }
+
+    if (typeof initializeViewToggle === "function") {
+        initializeViewToggle();
+    }
     
     // Add copy button event listener
     const copyCodeBtn = document.getElementById('copyCodeBtn');

--- a/webview/mermaid-init.js
+++ b/webview/mermaid-init.js
@@ -26,6 +26,11 @@ async function initializeAndRender() {
             securityLevel: "loose",
             fontFamily: "var(--vscode-font-family)",
             startOnLoad: true,
+            flowchart: {
+                nodeSpacing: 100,
+                rankSpacing: 150,
+                curve: 'basis'
+            },
             themeCSS: `
               /* Make subgraph labels opaque to hide edges behind */
               .flowchart-link {
@@ -38,6 +43,11 @@ async function initializeAndRender() {
               /* Add padding to subgraph content */
               .cluster {
                 padding: 20px !important;
+                margin: 30px !important;
+              }
+              /* Increase spacing between subgraphs */
+              .cluster + .cluster {
+                margin-left: 80px !important;
               }
               /* Style for subgraph buttons */
               .subgraph-buttons {
@@ -96,6 +106,19 @@ function updateFlowchart(diagram) {
         mermaidContainer.setAttribute('data-processed', 'false');
         mermaidContainer.innerHTML = '';
         
+        // Reinitialize Mermaid with fixed spacing
+        mermaid.initialize({
+            theme: "dark",
+            securityLevel: "loose",
+            fontFamily: "var(--vscode-font-family)",
+            startOnLoad: false,
+            flowchart: {
+                nodeSpacing: 100,
+                rankSpacing: 150,
+                curve: 'basis'
+            }
+        });
+        
         // Generate unique ID for this render
         const uniqueId = 'mermaid_' + Date.now();
         
@@ -124,6 +147,11 @@ function updateFlowchart(diagram) {
               /* Add padding to subgraph content */
               .cluster {
                 padding: 20px !important;
+                margin: 30px !important;
+              }
+              /* Increase spacing between subgraphs */
+              .cluster + .cluster {
+                margin-left: 80px !important;
               }
               /* Style for subgraph buttons */
               .subgraph-buttons {

--- a/webview/message-handler.js
+++ b/webview/message-handler.js
@@ -4,57 +4,62 @@ function handleExtensionMessage(event) {
     
     switch (message.command) {
         case 'updateFlowchart':
-            if (message.diagram) {
-                // Store the diagram code globally for expand functionality
+            if (typeof window.updateDiagramViews === 'function') {
+                window.updateDiagramViews({
+                    flowchart: message.diagram,
+                    connection: message.connectionDiagram,
+                    metadata: message.metadata,
+                    connectionMetadata: message.connectionMetadata
+                });
+            } else if (message.diagram) {
                 window.currentDiagramCode = message.diagram;
                 updateFlowchart(message.diagram);
-                // Store the diagram code for saving
                 if (typeof window.storeDiagramCode === 'function') {
                     window.storeDiagramCode(message.diagram);
                 }
+            }
 
-                // Minimal HUD cursor update
-                try {
-                    const info = document.getElementById('cursorInfo');
-                    const valueEl = document.getElementById('cursorValue');
-                    if (message.savedDiagram) {
-                        valueEl.textContent = "Saved Diagram: " + message.savedDiagram.name;
-                    } else {
-                        if (info && valueEl) {
-                            const es = message?.metadata?.entry_selection;
-                            if (es && es.type && es.type !== 'file') {
-                                let text = '';
-                                if (es.class) {
-                                    text += es.class + '.';
-                                }
-                                if (es.name) {
-                                    text += es.name;
-                                }
-                                valueEl.textContent = text || 'Unknown';
-                            } else {
-                                valueEl.textContent = 'Entire File';
-                            }
-                                info.style.display = '';
-                        }
-                    }
-                } catch (e) {
-                    console.warn('Cursor HUD update failed:', e);
-                }
-
-                // Update subgraph states if provided, otherwise reset
-                if (message.whitelist || message.forceCollapse || message.metadata) {
-                    if (typeof window.updateSubgraphStates === 'function') {
-                        window.updateSubgraphStates({
-                            whitelist: message.whitelist,
-                            forceCollapse: message.forceCollapse,
-                            metadata: message.metadata
-                        });
-                    }
+            // Minimal HUD cursor update
+            try {
+                const info = document.getElementById('cursorInfo');
+                const valueEl = document.getElementById('cursorValue');
+                if (message.savedDiagram) {
+                    valueEl.textContent = "Saved Diagram: " + message.savedDiagram.name;
                 } else {
-                    // Reset local UI states when a new diagram is loaded without state
-                    if (typeof window.resetSubgraphStates === 'function') {
-                        window.resetSubgraphStates();
+                    if (info && valueEl) {
+                        const es = message?.metadata?.entry_selection;
+                        if (es && es.type && es.type !== 'file') {
+                            let text = '';
+                            if (es.class) {
+                                text += es.class + '.';
+                            }
+                            if (es.name) {
+                                text += es.name;
+                            }
+                            valueEl.textContent = text || 'Unknown';
+                        } else {
+                            valueEl.textContent = 'Entire File';
+                        }
+                        info.style.display = '';
                     }
+                }
+            } catch (e) {
+                console.warn('Cursor HUD update failed:', e);
+            }
+
+            // Update subgraph states if provided, otherwise reset
+            if (message.whitelist || message.forceCollapse || message.metadata) {
+                if (typeof window.updateSubgraphStates === 'function') {
+                    window.updateSubgraphStates({
+                        whitelist: message.whitelist,
+                        forceCollapse: message.forceCollapse,
+                        metadata: message.metadata
+                    });
+                }
+            } else {
+                // Reset local UI states when a new diagram is loaded without state
+                if (typeof window.resetSubgraphStates === 'function') {
+                    window.resetSubgraphStates();
                 }
             }
             break;

--- a/webview/styles.css
+++ b/webview/styles.css
@@ -294,6 +294,56 @@ body {
     pointer-events: auto;
 }
 
+.view-toggle-wrapper {
+    position: absolute;
+    top: 30px;
+    left: 150px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 8px;
+    border-radius: 6px;
+    background-color: rgba(30, 30, 30, 0.7);
+    border: 1px solid var(--vscode-panel-border, #3c3c3c);
+    z-index: 200;
+    pointer-events: auto;
+}
+
+.view-tab {
+    background: transparent;
+    color: var(--vscode-editor-foreground, #ffffff);
+    border: none;
+    padding: 4px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.view-tab:hover {
+    background-color: var(--vscode-button-hoverBackground, #005a9e);
+}
+
+.view-tab.active {
+    background-color: var(--vscode-button-background, #0e639c);
+    color: var(--vscode-button-foreground, #ffffff);
+}
+
+.view-tab.disabled {
+    opacity: 0.5;
+    cursor: pointer;
+}
+
+.view-status-message {
+    font-size: 11px;
+    color: var(--vscode-descriptionForeground, #cccccc);
+    white-space: nowrap;
+}
+
+.view-status-message.hidden {
+    display: none;
+}
+
 .unfold-collapse-button {
     width: 32px;
     height: 32px;

--- a/webview/styles.css
+++ b/webview/styles.css
@@ -241,6 +241,20 @@ body {
     max-height: 80vh; /* Limit to 80% of viewport height */
 }
 
+/* Connection View specific spacing */
+.mermaid .cluster {
+    margin: 40px 20px !important;
+}
+
+.mermaid .cluster + .cluster {
+    margin-left: 100px !important;
+}
+
+/* Ensure proper spacing in Connection View diagrams */
+.mermaid svg .cluster rect {
+    margin: 20px !important;
+}
+
 .mermaid:active {
     cursor: grabbing;
 }

--- a/webview/view-toggle.js
+++ b/webview/view-toggle.js
@@ -1,0 +1,104 @@
+let currentView = 'flowchart';
+let diagrams = {
+    flowchart: '',
+    connection: ''
+};
+let connectionInfo = {
+    hasData: false,
+    message: ''
+};
+
+function renderCurrentView() {
+    const activeDiagram = currentView === 'connection' ? diagrams.connection : diagrams.flowchart;
+    if (activeDiagram) {
+        updateFlowchart(activeDiagram);
+        if (typeof window.storeDiagramCode === 'function') {
+            window.storeDiagramCode(activeDiagram);
+        }
+    }
+    updateStatusMessage();
+    updateTabState();
+}
+
+function updateStatusMessage() {
+    const statusEl = document.getElementById('viewStatusMessage');
+    if (!statusEl) {
+        return;
+    }
+
+    if (currentView === 'connection' && connectionInfo.message) {
+        statusEl.textContent = connectionInfo.message;
+        statusEl.classList.remove('hidden');
+    } else {
+        statusEl.classList.add('hidden');
+        statusEl.textContent = '';
+    }
+}
+
+function updateTabState() {
+    const flowTab = document.getElementById('flowchartViewTab');
+    const connectionTab = document.getElementById('connectionViewTab');
+
+    if (flowTab) {
+        flowTab.classList.toggle('active', currentView === 'flowchart');
+    }
+    if (connectionTab) {
+        connectionTab.classList.toggle('active', currentView === 'connection');
+        connectionTab.classList.toggle('disabled', !connectionInfo.hasData);
+        connectionTab.title = connectionInfo.hasData ? 'Show connection view' : 'Connection data is limited for this selection';
+    }
+}
+
+function setActiveView(view) {
+    if (view === currentView) {
+        return;
+    }
+    currentView = view;
+    renderCurrentView();
+}
+
+window.initializeViewToggle = function initializeViewToggle() {
+    const flowTab = document.getElementById('flowchartViewTab');
+    const connectionTab = document.getElementById('connectionViewTab');
+
+    if (flowTab) {
+        flowTab.addEventListener('click', () => setActiveView('flowchart'));
+    }
+    if (connectionTab) {
+        connectionTab.addEventListener('click', () => setActiveView('connection'));
+    }
+
+    updateTabState();
+};
+
+window.updateDiagramViews = function updateDiagramViews({ flowchart, connection, metadata, connectionMetadata }) {
+    diagrams.flowchart = flowchart || diagrams.flowchart;
+
+    if (connection) {
+        diagrams.connection = connection;
+    } else {
+        diagrams.connection = 'graph TD\n    noData["Connection information is not available for this selection"]';
+    }
+
+    if (connectionMetadata) {
+        connectionInfo = {
+            hasData: connectionMetadata.hasData !== false,
+            message: connectionMetadata.message || ''
+        };
+    } else {
+        connectionInfo = {
+            hasData: !!connection,
+            message: connection ? '' : 'Connection information is not available for this selection.'
+        };
+    }
+
+    if (!diagrams.flowchart && flowchart) {
+        diagrams.flowchart = flowchart;
+    }
+
+    renderCurrentView();
+};
+
+window.getCurrentView = function getCurrentView() {
+    return currentView;
+};


### PR DESCRIPTION
## Summary
- add a connection view service that builds a mermaid call hierarchy diagram using VS Code call hierarchy APIs
- expose connection depth settings and surface the additional diagram through the generate flowchart command and regeneration pipeline
- update the webview with a view toggle UI, new script, and styling to switch between flowchart and connection tabs

## Testing
- npm run compile
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ec22a4880c8320b5838d76579916a2